### PR TITLE
Invariant check bounty

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The bounties involve contribution to the Cosmos SDK. They will need to be implem
 
 | Task                              | Reward     | Claimed by |
 |:----------------------------------|:-----------|------------|
-| Improve speed of Invariant checks | 10000 JUNO |            |
+| Improve speed of Invariant checks | 10000 JUNO | @blazeroni |
 
 ### Improve speed of invariant checks
 Recently during Cosmos SDK chain halts, invariant checks have taken over 10 hours to pass. The poor performance is largely because invariant checks are single threaded, and as chain state grows they take longer and longer. Invariant checks are important and should not be skipped as they verify the state integrity of the chain.


### PR DESCRIPTION
This is a claim for the invariants check bounty.

I know the bounty says to provide multiple proofs, but simply running running junod on the genesis file is a quick enough test. Instead of 10 hours, it now takes about 30 seconds - less than 1% of the previous time.

The root problem was not the sequential nature of the invariant checks, but one particular method used by the "can-withdraw" check.  The issue is fairly deep in the cosmos code -- ultimately it was an issue with a cache not getting processed appropriately.

I submitted a PR (https://github.com/cosmos/cosmos-sdk/pull/12885) on cosmos-sdk which contains a fix for this issue.  It amortizes the cost of processing cache entries and speeds things up dramatically.  Since it's a lower level fix, it may also improve/prevent other issues unrelated to this specific issue.  

You can get a build of junod with the change included here: (https://github.com/blazeroni/juno-bounty/tree/v9.0.0-invariants).

Let me know if you have any questions or need any more info.  Cheers!